### PR TITLE
[BE][Feature] 카테고리 최소/최대 가격 조회 기능 구현

### DIFF
--- a/src/main/java/com/musinsa/musinsaassignment/controller/ItemController.java
+++ b/src/main/java/com/musinsa/musinsaassignment/controller/ItemController.java
@@ -1,10 +1,12 @@
 package com.musinsa.musinsaassignment.controller;
 
 import com.musinsa.musinsaassignment.dto.ItemByPriceAndCategoryResponse;
+import com.musinsa.musinsaassignment.dto.MinimaxPriceByCategoryResponse;
 import com.musinsa.musinsaassignment.dto.TotalPriceByBrandResponse;
 import com.musinsa.musinsaassignment.service.ItemService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
@@ -23,5 +25,10 @@ public class ItemController {
     @GetMapping("/getMinTotalPriceAndBrand")
     public TotalPriceByBrandResponse getMinTotalPriceAndBrand(){
         return itemService.getMinTotalPriceAndBrand();
+    }
+
+    @GetMapping("/getMinimaxPriceByCategory")
+    public MinimaxPriceByCategoryResponse get1(@RequestParam String category) {
+        return itemService.getMinimaxPriceByCategory(category);
     }
 }

--- a/src/main/java/com/musinsa/musinsaassignment/dto/ItemResponse.java
+++ b/src/main/java/com/musinsa/musinsaassignment/dto/ItemResponse.java
@@ -1,0 +1,22 @@
+package com.musinsa.musinsaassignment.dto;
+
+import com.musinsa.musinsaassignment.domain.Item;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class ItemResponse {
+
+    private String brandName;
+    private int price;
+
+    public ItemResponse(Item item) {
+        this.brandName = item.getBrand().getName();
+        this.price = item.getPrice();
+    }
+}

--- a/src/main/java/com/musinsa/musinsaassignment/dto/MinimaxPriceByCategoryResponse.java
+++ b/src/main/java/com/musinsa/musinsaassignment/dto/MinimaxPriceByCategoryResponse.java
@@ -1,0 +1,17 @@
+package com.musinsa.musinsaassignment.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class MinimaxPriceByCategoryResponse {
+
+    private ItemResponse min;
+    private ItemResponse max;
+
+}

--- a/src/main/java/com/musinsa/musinsaassignment/repository/ItemRepository.java
+++ b/src/main/java/com/musinsa/musinsaassignment/repository/ItemRepository.java
@@ -3,6 +3,9 @@ package com.musinsa.musinsaassignment.repository;
 import com.musinsa.musinsaassignment.domain.Item;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface ItemRepository extends JpaRepository<Item, Long>, CustomItemRepository{
 
+    List<Item> findByCategory_NameOrderByPrice(String category);
 }

--- a/src/main/java/com/musinsa/musinsaassignment/service/ItemService.java
+++ b/src/main/java/com/musinsa/musinsaassignment/service/ItemService.java
@@ -1,7 +1,7 @@
 package com.musinsa.musinsaassignment.service;
 
-import com.musinsa.musinsaassignment.dto.ItemByPriceAndCategoryResponse;
-import com.musinsa.musinsaassignment.dto.TotalPriceByBrandResponse;
+import com.musinsa.musinsaassignment.domain.Item;
+import com.musinsa.musinsaassignment.dto.*;
 import com.musinsa.musinsaassignment.repository.ItemRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -22,5 +22,15 @@ public class ItemService {
 
     public TotalPriceByBrandResponse getMinTotalPriceAndBrand(){
         return itemRepository.getMinTotalPriceAndBrand().get(0);
+    }
+
+    public MinimaxPriceByCategoryResponse getMinimaxPriceByCategory(String category){
+        List<Item> itemList = itemRepository.findByCategory_NameOrderByPrice(category);
+        int lastIndex = itemList.size()-1;
+
+        ItemResponse minItem = new ItemResponse(itemList.get(0));
+        ItemResponse maxItem = new ItemResponse(itemList.get(lastIndex));
+
+        return new MinimaxPriceByCategoryResponse(minItem, maxItem);
     }
 }


### PR DESCRIPTION
### 이슈 트래킹
#5 

### 작업 목록
- 입력받은 카테고리 명에 따라 최소/최대 가격 조회 기능 구현
입력양식 예시`localhost:8080/getMinimaxPriceByCategory?category=상의`
- ItemService.getMinimaxPriceByCategory: 해당 카테고리에 속한 모든 아이템을 가격순으로 정렬한 리스트를 가져와서 최저가 아이템(리스트 인덱스 0번), 최고가 아이템(리스트 마지막 인덱스)을 추출. 그 값들을 DTO(MinimaxPriceByCategoryResponse에 담아서 Return 하도록 함

`GET api/getMinimaxPriceByCategory`

<img width="819" alt="스크린샷 2022-07-16 오후 4 35 44" src="https://user-images.githubusercontent.com/87681380/179345666-9c46499b-baf2-4fcc-839d-a62598523979.png">

